### PR TITLE
カテゴリ機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'
 gem "font-awesome-sass"
 gem 'ancestry'
+gem 'jquery-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'
 gem "font-awesome-sass"
+gem 'ancestry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
+    ancestry (3.0.7)
+      activerecord (>= 3.2.0)
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
@@ -252,6 +254,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ancestry
   bootsnap (>= 1.1.0)
   byebug
   capistrano

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,10 @@ GEM
     io-like (0.3.1)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     kgio (2.11.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -269,6 +273,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails
   jbuilder (~> 2.5)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
   pry-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,6 @@
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
+//= require jquery
+//= require rails-ujs 
 //= require_tree .

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,12 +1,13 @@
 $(function(){
-  // カテゴリーセレクトボックスのオプションを作成
+  // カテゴリセレクトボックスのオプション
   function appendOption(category){
-    var html = `<option value="${category.name}" data-category="${category.id}">${category.name}</option>`;
+    let html = `<option value="${category.name}" data-category="${category.id}">${category.name}</option>`;
     return html;
   }
-  // 子カテゴリーの表示作成
+
+  // 子カテゴリのセレクトボックス作成
   function appendChidrenBox(insertHTML){
-    var childSelectHtml = '';
+    let childSelectHtml = '';
     childSelectHtml = `<div class='listing-select-wrapper__added' id= 'children_wrapper'>
                         <div class='listing-select-wrapper__box'>
                           <select class="listing-select-wrapper__box--select" id="child_category" name="category_id">
@@ -17,9 +18,10 @@ $(function(){
                       </div>`;
     $('.exhibition__main__container__topic__category').append(childSelectHtml);
   }
-  // 孫カテゴリーの表示作成
+
+  // 孫カテゴリのセレクトボックス作成
   function appendGrandchidrenBox(insertHTML){
-    var grandchildSelectHtml = '';
+    let grandchildSelectHtml = '';
     grandchildSelectHtml = `<div class='listing-select-wrapper__added' id= 'grandchildren_wrapper'>
                               <div class='listing-select-wrapper__box'>
                                 <select class="listing-select-wrapper__box--select" id="grandchild_category" name="category_id">
@@ -30,10 +32,11 @@ $(function(){
                             </div>`;
     $('.exhibition__main__container__topic__category').append(grandchildSelectHtml);
   }
-  // 親カテゴリー選択後のイベント
+
+  // 親カテゴリ選択後のイベント
   $('#parent_category').on('change', function(){
-    var parentCategory = document.getElementById('parent_category').value; //選択された親カテゴリーの名前を取得
-    if (parentCategory != "選択してください"){ //親カテゴリーが初期値でないことを確認
+    let parentCategory = document.getElementById('parent_category').value; // 選択された親カテゴリの名前を取得
+    if (parentCategory != "選択してください"){ // 親カテゴリが初期値でないときイベント発火
       $.ajax({
         url: '/items/get_category_children',
         type: 'GET',
@@ -41,26 +44,27 @@ $(function(){
         dataType: 'json'
       })
       .done(function(children){
-        $('#children_wrapper').remove(); //親が変更された時、子以下を削除するする
+        $('#children_wrapper').remove(); // 親カテゴリが変更されたとき、子・孫カテゴリを削除する
         $('#grandchildren_wrapper').remove();
-        var insertHTML = '';
+        let insertHTML = '';
         children.forEach(function(child){
           insertHTML += appendOption(child);
         });
         appendChidrenBox(insertHTML);
       })
       .fail(function(){
-        alert('カテゴリー取得に失敗しました');
+        alert('カテゴリー取得に失敗しました'); // カテゴリ取得失敗時にアラート表示
       })
-    }else{
-      $('#children_wrapper').remove(); //親カテゴリーが初期値になった時、子以下を削除するする
+    }else{ // 親カテゴリが初期値になったとき、子・孫カテゴリを削除する
+      $('#children_wrapper').remove(); 
       $('#grandchildren_wrapper').remove();
     }
   });
-  // 子カテゴリー選択後のイベント
+
+  // 子カテゴリ選択後のイベント
   $('.exhibition__main__container__topic__category').on('change', '#child_category', function(){
-    var childId = $('#child_category option:selected').data('category'); //選択された子カテゴリーのidを取得
-    if (childId != "---"){ //子カテゴリーが初期値でないことを確認
+    let childId = $('#child_category option:selected').data('category'); // 選択された子カテゴリのidを取得
+    if (childId != "選択してください"){ // 子カテゴリが初期値でないときイベント発火
       $.ajax({
         url: '/items/get_category_grandchildren',
         type: 'GET',
@@ -69,10 +73,10 @@ $(function(){
       })
       .done(function(grandchildren){
         if (grandchildren.length != 0) {
-          $('#grandchildren_wrapper').remove(); //子が変更された時、孫以下を削除するする
+          $('#grandchildren_wrapper').remove(); // 子カテゴリが変更されたとき孫カテゴリを削除する
           $('#size_wrapper').remove();
           $('#brand_wrapper').remove();
-          var insertHTML = '';
+          let insertHTML = '';
           grandchildren.forEach(function(grandchild){
             insertHTML += appendOption(grandchild);
           });
@@ -80,10 +84,10 @@ $(function(){
         }
       })
       .fail(function(){
-        alert('カテゴリー取得に失敗しました');
+        alert('カテゴリー取得に失敗しました'); // カテゴリ取得失敗時にアラート表示
       })
     }else{
-      $('#grandchildren_wrapper').remove(); //子カテゴリーが初期値になった時、孫以下を削除する
+      $('#grandchildren_wrapper').remove(); //子カテゴリが初期値になったとき孫カテゴリを削除する
     }
   });
 });

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,16 +1,89 @@
 $(function(){
-  // カテゴリセレクトボックスのオプション
+  // カテゴリーセレクトボックスのオプションを作成
   function appendOption(category){
-    let html = `<option value = "${category.name}" data-category = "${category.id}">${category.name}</option>`;
+    var html = `<option value="${category.name}" data-category="${category.id}">${category.name}</option>`;
     return html;
   }
-
-  // 子カテゴリの表示
-  function appendChildrenBox(insertHTML){
-    let childSelectHtml = '';
-    childSelectHtml = `<div class = "category-select-wrapper__added" id = "children_wrapper">
-                        <div class = "category-select-wrapper__box">
-                          <select class = "category-select-wrapper__box__select" id = "child_category" name = "category_id">
-                          `
+  // 子カテゴリーの表示作成
+  function appendChidrenBox(insertHTML){
+    var childSelectHtml = '';
+    childSelectHtml = `<div class='listing-select-wrapper__added' id= 'children_wrapper'>
+                        <div class='listing-select-wrapper__box'>
+                          <select class="listing-select-wrapper__box--select" id="child_category" name="category_id">
+                            <option value="---" data-category="---">選択してください</option>
+                            ${insertHTML}
+                          </select>
+                        </div>
+                      </div>`;
+    $('.exhibition__main__container__topic__category').append(childSelectHtml);
   }
-})
+  // 孫カテゴリーの表示作成
+  function appendGrandchidrenBox(insertHTML){
+    var grandchildSelectHtml = '';
+    grandchildSelectHtml = `<div class='listing-select-wrapper__added' id= 'grandchildren_wrapper'>
+                              <div class='listing-select-wrapper__box'>
+                                <select class="listing-select-wrapper__box--select" id="grandchild_category" name="category_id">
+                                  <option value="---" data-category="---">選択してください</option>
+                                  ${insertHTML}
+                                </select>
+                              </div>
+                            </div>`;
+    $('.exhibition__main__container__topic__category').append(grandchildSelectHtml);
+  }
+  // 親カテゴリー選択後のイベント
+  $('#parent_category').on('change', function(){
+    var parentCategory = document.getElementById('parent_category').value; //選択された親カテゴリーの名前を取得
+    if (parentCategory != "選択してください"){ //親カテゴリーが初期値でないことを確認
+      $.ajax({
+        url: '/items/get_category_children',
+        type: 'GET',
+        data: { parent_name: parentCategory },
+        dataType: 'json'
+      })
+      .done(function(children){
+        $('#children_wrapper').remove(); //親が変更された時、子以下を削除するする
+        $('#grandchildren_wrapper').remove();
+        var insertHTML = '';
+        children.forEach(function(child){
+          insertHTML += appendOption(child);
+        });
+        appendChidrenBox(insertHTML);
+      })
+      .fail(function(){
+        alert('カテゴリー取得に失敗しました');
+      })
+    }else{
+      $('#children_wrapper').remove(); //親カテゴリーが初期値になった時、子以下を削除するする
+      $('#grandchildren_wrapper').remove();
+    }
+  });
+  // 子カテゴリー選択後のイベント
+  $('.exhibition__main__container__topic__category').on('change', '#child_category', function(){
+    var childId = $('#child_category option:selected').data('category'); //選択された子カテゴリーのidを取得
+    if (childId != "---"){ //子カテゴリーが初期値でないことを確認
+      $.ajax({
+        url: '/items/get_category_grandchildren',
+        type: 'GET',
+        data: { child_id: childId },
+        dataType: 'json'
+      })
+      .done(function(grandchildren){
+        if (grandchildren.length != 0) {
+          $('#grandchildren_wrapper').remove(); //子が変更された時、孫以下を削除するする
+          $('#size_wrapper').remove();
+          $('#brand_wrapper').remove();
+          var insertHTML = '';
+          grandchildren.forEach(function(grandchild){
+            insertHTML += appendOption(grandchild);
+          });
+          appendGrandchidrenBox(insertHTML);
+        }
+      })
+      .fail(function(){
+        alert('カテゴリー取得に失敗しました');
+      })
+    }else{
+      $('#grandchildren_wrapper').remove(); //子カテゴリーが初期値になった時、孫以下を削除する
+    }
+  });
+});

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,0 +1,16 @@
+$(function(){
+  // カテゴリセレクトボックスのオプション
+  function appendOption(category){
+    let html = `<option value = "${category.name}" data-category = "${category.id}">${category.name}</option>`;
+    return html;
+  }
+
+  // 子カテゴリの表示
+  function appendChildrenBox(insertHTML){
+    let childSelectHtml = '';
+    childSelectHtml = `<div class = "category-select-wrapper__added" id = "children_wrapper">
+                        <div class = "category-select-wrapper__box">
+                          <select class = "category-select-wrapper__box__select" id = "child_category" name = "category_id">
+                          `
+  }
+})

--- a/app/assets/stylesheets/_category.scss
+++ b/app/assets/stylesheets/_category.scss
@@ -1,3 +1,4 @@
+// ヘッダーのカテゴリメニュー用
 .parent,.child,.grandchild{
   display: none;
 }
@@ -37,6 +38,8 @@
       }
     }
   }
+
+  // 親、子、孫カテゴリにカーソルを合わせたときの表示
   &:hover{
     .parent{
       display: block;

--- a/app/assets/stylesheets/_category.scss
+++ b/app/assets/stylesheets/_category.scss
@@ -7,7 +7,7 @@
   z-index: 2;
   .category-box{
     position: absolute;
-    max-height: 670px;
+    height: 600px;
     background-color: white;
     .parent,.child,.grandchild{
       box-shadow: 1px 1px 4px;

--- a/app/assets/stylesheets/_category.scss
+++ b/app/assets/stylesheets/_category.scss
@@ -1,0 +1,69 @@
+.parent,.child,.grandchild{
+  display: none;
+}
+.category-area{
+  cursor: pointer;
+  position: relative;
+  z-index: 2;
+  .category-box{
+    position: absolute;
+    max-height: 670px;
+    background-color: white;
+    .parent,.child,.grandchild{
+      box-shadow: 1px 1px 4px;
+      height: 100%;
+      background-color: white;
+    }
+    .parent-content{
+      padding: 6px;
+      color: black;
+      &:hover{
+        background-color: #3ccace;
+        color: white;
+      }
+      .child-content{
+        padding: 4px 6px;
+        color: black;
+        &:hover{
+          background-color: #f1f1f1;
+        }
+        .grandchild-content{
+          padding: 4px 6px;
+          color: black;
+          &:hover{
+            background-color: #f1f1f1;
+          }
+        }
+      }
+    }
+  }
+  &:hover{
+    .parent{
+      display: block;
+      .parent-content{
+        width: 260px;
+        &:hover{
+          .child{
+            width: 260px;
+            display: block;
+            position: absolute;
+            top: 0;
+            left: 260px;
+            .child-content{
+              display: block;
+              &:hover{
+                .grandchild{
+                  width: 260px;
+                  display: block;
+                  position: absolute;
+                  top: 0;
+                  left: 260px;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 @import "config/mixin";
 @import "header";
 @import "footer";
+@import "category";
 
 @import "users/show";
 @import "users/logout";

--- a/app/assets/stylesheets/items/_exhibition.scss
+++ b/app/assets/stylesheets/items/_exhibition.scss
@@ -65,11 +65,15 @@
           background-color: $image-color;
           padding: 1px 4px 2px;
         }
-        .category-select-wrapper__box__select{
-          height: 46px;
-          width: 620px;
-          font-weight: normal;
+        &__category{
+          .listing-select-wrapper__box--select{
+            margin-bottom: 14px;
+            height: 46px;
+            width: 620px;
+            font-weight: normal;
+          }
         }
+        
       }
 
       &__uploader{

--- a/app/assets/stylesheets/items/_exhibition.scss
+++ b/app/assets/stylesheets/items/_exhibition.scss
@@ -65,6 +65,11 @@
           background-color: $image-color;
           padding: 1px 4px 2px;
         }
+        .category-select-wrapper__box__select{
+          height: 46px;
+          width: 620px;
+          font-weight: normal;
+        }
       }
 
       &__uploader{

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,9 @@
 class ApplicationController < ActionController::Base
 
   before_action :basic_auth, if: :production?
+  before_action :set_category
 
   private
-
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
       username == Rails.application.credentials[:basic_auth][:user] &&
@@ -15,4 +15,8 @@ class ApplicationController < ActionController::Base
     Rails.env.production?
   end
   
+  # カテゴリ情報の取得(親要素のみ)
+  def set_category
+    @parents = Category.where(ancestry: nil)
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,7 @@ class ItemsController < ApplicationController
 
   # 商品出品アクション
   def exhibition
-    # セレクトボックスの初期値
+    # カテゴリセレクトボックスの初期値
     @category_parent_array = ["選択してください"]
     # DBから親カテゴリのみ抽出し、配列へ追加
     Category.where(ancestry: nil).each do |parent|
@@ -19,12 +19,13 @@ class ItemsController < ApplicationController
     end
   end
 
-  # 子、孫カテゴリ登録用アクション
+  # 親カテゴリ選択後の子カテゴリ表示
   def get_category_children
     # 選択された親カテゴリに紐付く子カテゴリの配列を取得
     @category_children = Category.find_by(name: "#{params[:parent_name]}", ancestry: nil).children
   end
 
+  # 子カテゴリ選択後の孫カテゴリ表示
   def get_category_grandchildren
     # 選択された子カテゴリに紐付く孫カテゴリの配列を取得
     @category_grandchildren = Category.find("#{params[:child_id]}").children

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,7 +9,24 @@ class ItemsController < ApplicationController
   def confimation
   end
 
+  # 商品出品アクション
   def exhibition
+    # セレクトボックスの初期値
+    @category_parent_array = ["選択してください"]
+    # DBから親カテゴリのみ抽出し、配列へ追加
+    Category.where(ancestry: nil).each do |parent|
+      @category_parent_array << parent.name
+    end
   end
 
+  # 子、孫カテゴリ登録用アクション
+  def get_category_children
+    # 選択された親カテゴリに紐付く子カテゴリの配列を取得
+    @category_children = Category.find_by(name: "#{params[:parent_name]}", ancestry: nil).children
+  end
+
+  def get_category_grandchildren
+    # 選択された子カテゴリに紐付く孫カテゴリの配列を取得
+    @category_grandchildren = Category.find("#{params[:child_id]}").children
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,12 +11,8 @@ class ItemsController < ApplicationController
 
   # 商品出品アクション
   def exhibition
-    # カテゴリセレクトボックスの初期値
-    @category_parent_array = ["選択してください"]
-    # DBから親カテゴリのみ抽出し、配列へ追加
-    Category.where(ancestry: nil).each do |parent|
-      @category_parent_array << parent.name
-    end
+    # # DBから親カテゴリのみ抽出し、配列へ追加
+    @category_parent_array = Category.where(ancestry: nil).pluck(:name).unshift("選択してください")
   end
 
   # 親カテゴリ選択後の子カテゴリ表示

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,4 +2,5 @@ class Category < ApplicationRecord
 
   has_many :items
   has_ancestry
+  
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,5 @@
+class Category < ApplicationRecord
+
+  has_many :items
+  has_ancestry
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,5 @@
+class Item < ApplicationRecord
+
+  belongs_to :category
+  
+end

--- a/app/views/items/exhibition.html.haml
+++ b/app/views/items/exhibition.html.haml
@@ -37,7 +37,6 @@
           .listing-select-wrapper
             .listing-select-wrapper__box
               = form.select :category, @category_parent_array, {}, {class: 'listing-select-wrapper__box--select', id: 'parent_category'}
-        -# =form.select:category,[],prompt:"選択してください"
 
         .exhibition__main__container__topic
           %label 商品の状態

--- a/app/views/items/exhibition.html.haml
+++ b/app/views/items/exhibition.html.haml
@@ -30,13 +30,13 @@
 
       .exhibition__main__container
         %p 商品の詳細
-        .exhibition__main__container__topic
+        .exhibition__main__container__topic__category
           %label カテゴリー
           %span 必須
           -# カテゴリ選択欄の表示
-          .category-select-wrapper
-            .category-select-wrapper__box
-              = form.select :category, @category_parent_array, {}, {class: "category-select-wrapper__box__select", id: "parent_category"}
+          .listing-select-wrapper
+            .listing-select-wrapper__box
+              = form.select :category, @category_parent_array, {}, {class: 'listing-select-wrapper__box--select', id: 'parent_category'}
         -# =form.select:category,[],prompt:"選択してください"
 
         .exhibition__main__container__topic

--- a/app/views/items/exhibition.html.haml
+++ b/app/views/items/exhibition.html.haml
@@ -33,7 +33,12 @@
         .exhibition__main__container__topic
           %label カテゴリー
           %span 必須
-        =form.select:category,[],prompt:"選択してください"
+          -# カテゴリ選択欄の表示
+          .category-select-wrapper
+            .category-select-wrapper__box
+              = form.select :category, @category_parent_array, {}, {class: "category-select-wrapper__box__select", id: "parent_category"}
+        -# =form.select:category,[],prompt:"選択してください"
+
         .exhibition__main__container__topic
           %label 商品の状態
           %span 必須
@@ -83,9 +88,9 @@
   .exhibition__footer
     %ul.exhibition__footer__poricy
       %li= link_to "プライバシーポリシー","#"
-      %li= link_to "メルカリ利用規約","#"
+      %li= link_to "FURIMA利用規約","#"
       %li= link_to "特定商取引に関する法律表記","#"
     = image_tag('logo-mini.png',height:"65px",width:"80px",class:"logo")
-    %p © Mercari, Inc.
+    %p © FURIMA, Inc.
       
       

--- a/app/views/items/get_category_children.json.jbuilder
+++ b/app/views/items/get_category_children.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @category_children do |child|
+  json.id   child.id
+  json.name child.name
+end

--- a/app/views/items/get_category_children.json.jbuilder
+++ b/app/views/items/get_category_children.json.jbuilder
@@ -1,3 +1,4 @@
+# 子カテゴリ表示
 json.array! @category_children do |child|
   json.id child.id
   json.name child.name

--- a/app/views/items/get_category_children.json.jbuilder
+++ b/app/views/items/get_category_children.json.jbuilder
@@ -1,4 +1,4 @@
 json.array! @category_children do |child|
-  json.id   child.id
+  json.id child.id
   json.name child.name
 end

--- a/app/views/items/get_category_grandchildren.json.jbuilder
+++ b/app/views/items/get_category_grandchildren.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @category_grandchildren do |grandchild|
+  json.id   grandchild.id
+  json.name grandchild.name
+end

--- a/app/views/items/get_category_grandchildren.json.jbuilder
+++ b/app/views/items/get_category_grandchildren.json.jbuilder
@@ -1,4 +1,4 @@
 json.array! @category_grandchildren do |grandchild|
-  json.id   grandchild.id
+  json.id grandchild.id
   json.name grandchild.name
 end

--- a/app/views/items/get_category_grandchildren.json.jbuilder
+++ b/app/views/items/get_category_grandchildren.json.jbuilder
@@ -1,3 +1,4 @@
+# 孫カテゴリ表示
 json.array! @category_grandchildren do |grandchild|
   json.id grandchild.id
   json.name grandchild.name

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -49,17 +49,21 @@
             出品者
           %td.item__box__table__user__input
             hoge
+
+        -# カテゴリ表示(商品出品機能未実装のため、リンクを文字列にしています。)
+        -# 商品出品機能実装後、リンクが登録されたカテゴリ名になっているか確認します。(リンクの"""を外す)
         %tr
           %td.item__box__table__category__title
             カテゴリー
           %td.item__box__table__category__input
-            %ul
-              %li.category__gender
-                =link_to 'メンズ', '#'
-              %li.category__name
-                =link_to 'ジャケット、アウター', '#'
-              %li.category__detalis
-                =link_to 'ノーカラージャケット', '#'
+            = link_to "#", class: "category-link" do
+              %br
+              = "@item.category.parent.parent.name" # 親カテゴリ名
+              %br
+              = "@item.category.parent.name" # 子カテゴリ名
+              %br
+              = "@item.category.name" # 孫カテゴリ名
+
         %tr
           %td.item__box__table__brand__title
             ブランド

--- a/app/views/layouts/_category.html.haml
+++ b/app/views/layouts/_category.html.haml
@@ -1,0 +1,16 @@
+.category-box
+  -# カテゴリの親要素の取得
+  .parent
+    - @parents.each do |parent|
+      .parent-content
+        = parent.name
+        -# カテゴリの子要素の取得
+        .child
+          - parent.children.each do |child|
+            .child-content
+              = child.name
+              -# カテゴリの孫要素の取得
+              .grandchild
+                - child.children.each do |grandchild|
+                  .grandchild-content
+                    = grandchild.name

--- a/app/views/layouts/_category.html.haml
+++ b/app/views/layouts/_category.html.haml
@@ -1,16 +1,17 @@
-.category-box
-  -# カテゴリの親要素の取得
-  .parent
-    - @parents.each do |parent|
-      .parent-content
-        = parent.name
-        -# カテゴリの子要素の取得
-        .child
-          - parent.children.each do |child|
-            .child-content
-              = child.name
-              -# カテゴリの孫要素の取得
-              .grandchild
-                - child.children.each do |grandchild|
-                  .grandchild-content
-                    = grandchild.name
+
+-# カテゴリの親要素の取得
+.parent
+  - @parents.each do |parent|
+    .parent-content
+      = parent.name
+      -# カテゴリの子要素の取得
+      .child
+        - parent.children.each do |child|
+          .child-content
+            = child.name
+            -# カテゴリの孫要素の取得
+            .grandchild
+              - child.children.each do |grandchild|
+                .grandchild-content
+                  = grandchild.name
+                  

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,7 +1,8 @@
-%header
+#request{action: request.path}
+.header
   .header-content
     .header-main
-      =image_tag "/assets/logo.png",class: "header-main__image"
+      =image_tag "logo.png",class: "header-main__image"
       .heaer-main__search
         %input{type: "text_field",class: "header-main__search--field",placeholder: "キーワードから探す"}
         =link_to "#",class: "header-main__search--btn" do
@@ -10,12 +11,15 @@
     .header-nav
       %ul
         %li.header-nav-left
-          カテゴリー
+          .category-area
+            カテゴリー
+            .category-box
+              = render "layouts/category"
         %li.header-nav-left
           ブランド     
       %ul
         %li.header-nav-right
-          =link_to "ログイン","#",class: "header-nav-right__btn"
+          =link_to "ログイン","/view/new",class: "header-nav-right__btn"
         %li.header-nav-right
-          =link_to "新規会員登録","#",class: "header-nav-right__btn"
+          =link_to "新規会員登録","/view",class: "header-nav-right__btn"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,12 @@ Rails.application.routes.draw do
     collection do
       get 'confimation'
       get 'exhibition'
+      # 子、孫カテゴリ登録用アクション
+      get 'get_category_children',      defaults: { format: 'json' }
+      get 'get_category_grandchildren', defaults: { format: 'json' }
     end
   end
+
   resources :users, only: [:show] do
     collection do
       get 'logout'

--- a/db/migrate/20200525072436_create_categories.rb
+++ b/db/migrate/20200525072436_create_categories.rb
@@ -1,0 +1,8 @@
+class CreateCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200525072455_create_items.rb
+++ b/db/migrate/20200525072455_create_items.rb
@@ -1,0 +1,8 @@
+class CreateItems < ActiveRecord::Migration[5.2]
+  def change
+    create_table :items do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200525072939_add_ancestry_to_category.rb
+++ b/db/migrate/20200525072939_add_ancestry_to_category.rb
@@ -1,0 +1,6 @@
+class AddAncestryToCategory < ActiveRecord::Migration[5.2]
+  def change
+    add_column :categories, :ancestry, :string
+    add_index  :categories, :ancestry
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,28 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_05_25_072939) do
+
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "ancestry"
+    t.index ["ancestry"], name: "index_categories_on_ancestry"
+  end
+
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-# カテゴリデータの導入
+# カテゴリデータの導入(今後必要に応じて追加する)
 
 lady = Category.create(name: "レディース")
 lady_1 = lady.children.create(name: "トップス")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,13 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# カテゴリデータの導入
+
+lady = Category.create(name: "レディース")
+lady_1 = lady.children.create(name: "トップス")
+lady_1.children.create([{name: "Tシャツ/カットソー(半袖/袖なし)"},{name: "Tシャツ/カットソー(七分/長袖)"}])
+lady_2 = lady.children.create(name: "ジャケット/アウター")
+lady_2.children.create([{name: "テーラードジャケット"},{name: "Gジャン/デニムジャケット"}])
+
+men = Category.create(name: "メンズ")
+men_1 = men.children.create(name: "トップス")
+men_1.children.create([{name: "Tシャツ/カットソー(半袖/袖なし)"},{name: "Tシャツ/カットソー(七分/長袖)"}])
+men_2 = men.children.create(name: "ジャケット/アウター")
+men_2.children.create([{name: "テーラードジャケット"},{name: "Gジャン/デニムジャケット"}])

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
・What
商品のカテゴリ機能を以下にて実装する。
gem "ancestry"導入にてカテゴリの多層構造の実現
seeds.rb へ3層構造のカテゴリデータを挿入(今後必要に応じて追加する)
(商品出品画面)
routes.rb へAjaxで動くアクションのルートを作成
items_controller.rb へ出品時カテゴリ登録用アクションの追加
category.js へカテゴリボックス追加イベント記述
(ヘッダー内カテゴリエリア)
application_controller.rb へカテゴリ取得アクション追加
_category.html.haml へカテゴリ表示ビュー追加
(商品詳細画面)
show.html.haml へカテゴリ名表示

カテゴリボックス追加画面
https://gyazo.com/aa7c3ed8ce6285d8798d360bcd657711
ヘッダー内カテゴリエリア
https://gyazo.com/ce23d3499f2a0914c901eb76701852cf

・Why
必須機能実装のため
商品をカテゴリ毎に区別できる様にするため