### PR TITLE
[WIP]商品詳細画面に画像表示

### DIFF
--- a/app/assets/javascripts/show_image.js
+++ b/app/assets/javascripts/show_image.js
@@ -1,0 +1,7 @@
+// カーソルを合わせた画像をメイン画像へ変更する
+$(document).on('turbolinks:load', function() {
+  $('.image__list').hover(function () {
+    var $src = $(this).attr('src');
+    $('.main__image').attr('src', $src);
+  });
+});

--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -5,7 +5,7 @@
 }
 .background{
   background-color: $backColor;
-  height: 2100px;
+  height: 2200px;
   width: 100vw;
   .category{
     background-color:white;
@@ -32,7 +32,7 @@
   }
   .item__box{
     background-color: white;
-    height: 1550px;
+    height: 1650px;
     width: 580px;
     margin: 0 auto;
     margin-bottom: 10px;
@@ -47,7 +47,7 @@
       font-weight: bold;
     }
     &__body{
-      height: 440px;
+      height: 540px;
       &--topImage{
         height: 350px;
         text-align: center;
@@ -62,6 +62,7 @@
         .subimages__box{
           display: flex;
           justify-content: center;
+          // flex-wrap: wrap;
           img{
             object-fit: cover;
             cursor: default;

--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -53,12 +53,23 @@
         text-align: center;
         line-height: 350px;
         margin-bottom: 10px;
+        img{
+          object-fit: cover;  // 中央でトリミングされた表示に変更する
+        }
       }
       &--subImages{
         height: 90px;
         .subimages__box{
           display: flex;
           justify-content: center;
+          img{
+            object-fit: cover;
+            cursor: default;
+            opacity: 0.5;
+          }
+          img:hover{
+            opacity: 1.0;
+          }
         }
       }
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -61,8 +61,7 @@ class ItemsController < ApplicationController
 
   private
   def item_params
-    params.require(:item).permit(:category_id,:url, :name, :description, :stats, :delivery_charge, :delivery_origin_area, :days_until_delivery, :user_id, :price, :saler_id, :buyer_id, images_attributes:[:url, :_destroy, :id])
-    #ログイン機能実装後付け加える→ .merge(user_id: current_user.id)(saler_id: current_user_id )
+    params.require(:item).permit(:category_id,:url, :name, :description, :stats, :delivery_charge, :delivery_origin_area, :days_until_delivery, :user_id, :price, :saler_id, :buyer_id, images_attributes:[:url, :_destroy, :id]).merge(user_id: current_user.id, saler_id: current_user.id )
   end
 
   def set_item  # itemデータの取得

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,6 +1,6 @@
 class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
-  process resize_to_fit: [100, 100]  
+  process resize_to_fit: [1000, 1000] # 画像サイズを大きくするため100→1000へ変更
   
 
   if Rails.env.development?

--- a/app/views/items/exhibition.html.haml
+++ b/app/views/items/exhibition.html.haml
@@ -91,13 +91,6 @@
         %p 販売手数料(10%)
         %hr/
 
-        %p user_id（仮）
-        =form.number_field :user_id,id:"price"
-        %p saler_id（仮）
-        =form.number_field :saler_id,id:"price"
-        -# ----------↑ログイン機能実装後削除-------------
-
-
       .exhibition__main__container
         %p 販売利益
 
@@ -109,7 +102,6 @@
       .exhibition__main__precaution
         %p 禁止されている行為および出品物を必ずご確認ください。偽ブランド品や盗品物などの販売は犯罪であり、法律により処罰される可能性があります。 また、出品をもちまして加盟店規約に同意したことになります。
         
-
   .exhibition__footer
     %ul.exhibition__footer__poricy
       %li= link_to "プライバシーポリシー","#"

--- a/app/views/items/exhibition.html.haml
+++ b/app/views/items/exhibition.html.haml
@@ -1,6 +1,6 @@
 .exhibition
   .exhibition__top
-    = image_tag('logo.png',height:"49px",width:"185px",class:"logo")
+    = link_to image_tag('logo.png',height:"49px",width:"185px",class:"logo"), root_path # ロゴのリンク先をトップページへ指定
   .exhibition__main
     =form_with(model: @item,local:true,class:"sell-form dropzone", id:"item-dropzone") do |form|
       .exhibition__main__container

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -32,8 +32,16 @@
           %ol.subimages__box
             - @item.images.each do |image| # 複数投稿された画像をリスト表示
               %li
-                = image_tag image.url.url, size: '120x88', class: 'image__list'
-                = image_tag ('logo.png'), size: '120x88', class: 'image__list' # 画像複数投稿機能未実装のため、テスト画像の表示
+                = image_tag image.url.url, size: '110x88', class: 'image__list'
+                = image_tag image.url.url, size: '110x88', class: 'image__list'
+                = image_tag image.url.url, size: '110x88', class: 'image__list'
+                = image_tag image.url.url, size: '110x88', class: 'image__list'
+                = image_tag image.url.url, size: '110x88', class: 'image__list'
+                = image_tag image.url.url, size: '110x88', class: 'image__list'
+                = image_tag image.url.url, size: '110x88', class: 'image__list'
+                = image_tag image.url.url, size: '110x88', class: 'image__list'
+                = image_tag image.url.url, size: '110x88', class: 'image__list'
+                = image_tag ('logo.png'), size: '110x88', class: 'image__list' # 画像複数投稿機能未実装のため、テスト画像の表示
 
       .item__box__price
         ¥

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -27,15 +27,14 @@
         = @item.name
       .item__box__body
         .item__box__body--topImage
-          =image_tag 'sushi2.png',class: 'top-image',size: '550x350'
+          = image_tag @item.images.first.url.url, size: '400x350', class: 'main__image' # 投稿された画像の1枚目をメイン画像に指定
         .item__box__body--subImages
           %ol.subimages__box
-            %li
-              =image_tag 'sushi.png', size: '120x88'
-            %li
-              =image_tag 'sushi3.png', size: '120x88'
-            %li
-              =image_tag 'sushi4.png', size: '120x88'
+            - @item.images.each do |image| # 複数投稿された画像をリスト表示
+              %li
+                = image_tag image.url.url, size: '120x88', class: 'image__list'
+                = image_tag ('logo.png'), size: '120x88', class: 'image__list' # 画像複数投稿機能未実装のため、テスト画像の表示
+
       .item__box__price
         ¥
         = @item.price

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -27,7 +27,7 @@
         = @item.name
       .item__box__body
         .item__box__body--topImage
-          = image_tag @item.images.first.url.url, size: '400x350', class: 'main__image' # 投稿された画像の1枚目をメイン画像に指定
+          = image_tag @item.images.first.url.url, size: '500x350', class: 'main__image' # 投稿された画像の1枚目をメイン画像に指定
         .item__box__body--subImages
           %ol.subimages__box
             - @item.images.each do |image| # 複数投稿された画像をリスト表示

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -2,7 +2,6 @@
 .header
   .header-content
     .header-main
-      -# =image_tag "logo.png",class: "header-main__image"
       = link_to image_tag("logo.png", class: "header-main__image"), root_path
       .heaer-main__search
         %input{type: "text_field",class: "header-main__search--field",placeholder: "キーワードから探す"}

--- a/app/views/users/_menu_bar.html.haml
+++ b/app/views/users/_menu_bar.html.haml
@@ -1,6 +1,6 @@
 -# メニューリンク一覧
 - contents = ["マイページ", "出品する", "出品した商品", "購入した商品", "発送元・お届け先住所変更", "クレジットカードの登録", "ログアウト"]
-- links    = ["show", "", "", "", "addresses", "card_index", "logout"]
+- links    = ["show", "/items/exhibition", "", "", "addresses", "card_index", "logout"]
 
 .mypage-wrapper__contents__left
   - contents.each.with_index(0) do |content, i|


### PR DESCRIPTION
What
商品詳細画面に商品画像を表示させる
・投稿された１番目の画像をメイン画像に指定して表示する
・画像をリスト形式で表示し、カーソルを合わせた画像がメイン画像に変化する(show_image.js参照)
https://gyazo.com/8601fea4d91cf15abc659c0e5ad5278d
　※画像複数投稿機能未実装のため、テスト画像の表示(画像1枚投稿は可能)
・image_uploader.rbにて、resize_to_fit: [1000, 1000]へ変更(サイズを大きくし画質を良くするため)
・マイページのメニューバーから出品画面へのリンク作成

Why
詳細画面にて商品画像を確認するため