### PR TITLE
[WIP] 商品出品・詳細画面の修正

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,4 +1,4 @@
-$(function(){
+$(document).on('turbolinks:load',function(){
   // カテゴリセレクトボックスのオプション
   function appendOption(category){
     let html =`<option value='${category.id}' data-category='${category.id}'>${category.name}</option>`;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -32,16 +32,7 @@
           %ol.subimages__box
             - @item.images.each do |image| # 複数投稿された画像をリスト表示
               %li
-                = image_tag image.url.url, size: '110x88', class: 'image__list'
-                = image_tag image.url.url, size: '110x88', class: 'image__list'
-                = image_tag image.url.url, size: '110x88', class: 'image__list'
-                = image_tag image.url.url, size: '110x88', class: 'image__list'
-                = image_tag image.url.url, size: '110x88', class: 'image__list'
-                = image_tag image.url.url, size: '110x88', class: 'image__list'
-                = image_tag image.url.url, size: '110x88', class: 'image__list'
-                = image_tag image.url.url, size: '110x88', class: 'image__list'
-                = image_tag image.url.url, size: '110x88', class: 'image__list'
-                = image_tag ('logo.png'), size: '110x88', class: 'image__list' # 画像複数投稿機能未実装のため、テスト画像の表示
+                = image_tag image.url.url, size: '110x90', class: 'image__list'
 
       .item__box__price
         ¥
@@ -49,7 +40,7 @@
       .item__box__price--underText
         (税込) 送料込み
       .item__box__explanation
-        = @item.description
+        = simple_format @item.description # simple_formatで改行に対応
       %table.item__box__table
         %colgroup
         %tr


### PR DESCRIPTION
・What
画像複数枚投稿機能実装に伴い、商品詳細画面を修正した。
また、商品説明欄が改行に対応する様simple_formatへ変更した。
画面遷移の高速化のため、turbolinks:loadをcategory.jsへ追記（出品画面にて）

・Why
商品詳細画面を見やすくするため。
商品出品の画面遷移の高速化のため