### PR TITLE
購入機能の実装

### DIFF
--- a/app/assets/stylesheets/items/_confimation.scss
+++ b/app/assets/stylesheets/items/_confimation.scss
@@ -43,6 +43,7 @@
             &__image {
               .image {
                 width:100px;
+                object-fit: cover;
               }
             }
             &__item {
@@ -123,10 +124,18 @@
           border-top: 1px solid #f5f5f5;
           &--btn {
             border: 1px solid #888;
-            background: #888;
+            background-color: #33CCCC;
             color: #fff;
             width: 100%;
             line-height: 48px;
+          }
+          &--buy {
+            display: block;
+            height: 50px;
+            line-height: 50px;
+            text-align: center;
+            background-color: #888;
+            color: white;
           }
         }
       }

--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -155,7 +155,7 @@
   .item-btn{
     width: 300px;
     margin: 30px auto;
-    &__edit, &__delete, &__buy{
+    &__edit, &__delete,,&__sold, &__buy{
       display: block;
       width: 300px;
       height: 50px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,9 +27,11 @@ class ItemsController < ApplicationController
   end
   
   def confimation
+    @item = Item.find(params[:id])
+    @image = Image.find(params[:id])
     @payment = Payment.find_by(user_id: current_user.id)
-    if @payment.blank?
-    else
+    @address = Address.find_by(user_id: current_user.id)
+    if @payment.present?
       Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_PRIVATE_KEY]
       customer = Payjp::Customer.retrieve(@payment.customer_id)
       @default_card_information = customer.cards.retrieve(@payment.card_id)
@@ -39,6 +41,26 @@ class ItemsController < ApplicationController
       @payment_brand = @default_card_information.brand 
     end
   end
+
+  def pay
+    @item = Item.find(params[:id])
+    @payment = Payment.find_by(user_id: current_user.id)
+    Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_PRIVATE_KEY]
+    charge = Payjp::Charge.create(
+      amount: @item.price,
+      customer: @payment.customer_id,
+      currency: 'jpy',
+    )
+    @item_buyer = Item.find(params[:id])
+    @item_buyer.update(buyer_id: current_user.id)
+    
+    flash[:notice] = "#{@item.name}を購入しました"
+    redirect_to root_path
+  end
+
+
+
+
   
   # 商品出品アクション
   def exhibition

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   
   before_action :set_item, only:[:show, :destroy]
+  before_action :set_confimation, only: :confimation
   
   def index
     @items = Item.where(buyer_id: nil).includes([:images]).limit(6)
@@ -27,18 +28,13 @@ class ItemsController < ApplicationController
   end
   
   def confimation
-    @item = Item.find(params[:id])
-    @image = Image.find(params[:id])
-    @payment = Payment.find_by(user_id: current_user.id)
-    @address = Address.find_by(user_id: current_user.id)
     if @payment.present?
       Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_PRIVATE_KEY]
       customer = Payjp::Customer.retrieve(@payment.customer_id)
       @default_card_information = customer.cards.retrieve(@payment.card_id)
       @exp_month =@default_card_information.exp_month.to_s
       @exp_year = @default_card_information.exp_year.to_s.slice(2,3)
-      # クレジットカードのアイコンを表示するためにカード会社を取得
-      @payment_brand = @default_card_information.brand 
+      @payment_brand = @default_card_information.brand   # クレジットカードのアイコンを表示するためにカード会社を取得
     end
   end
 
@@ -105,6 +101,13 @@ class ItemsController < ApplicationController
 
   def set_item  # itemデータの取得
     @item = Item.find(params[:id])
+  end
+
+  def set_confimation
+    @item = Item.find(params[:id])
+    @image = Image.find(params[:id])
+    @payment = Payment.find_by(user_id: current_user.id)
+    @address = Address.find_by(user_id: current_user.id)
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,9 @@
 class ItemsController < ApplicationController
   
-  before_action :set_item, only:[:show, :destroy]
+  before_action :set_item, only:[:show, :destroy, :confimation, :pay]
   before_action :set_confimation, only: :confimation
-  
+  before_action :set_payment, only: [:confimation, :pay]
+
   def index
     @items = Item.where(buyer_id: nil).includes([:images]).limit(6)
   end
@@ -39,15 +40,13 @@ class ItemsController < ApplicationController
   end
 
   def pay
-    @item = Item.find(params[:id])
-    @payment = Payment.find_by(user_id: current_user.id)
     Payjp.api_key = Rails.application.credentials.payjp[:PAYJP_PRIVATE_KEY]
     charge = Payjp::Charge.create(
       amount: @item.price,
       customer: @payment.customer_id,
       currency: 'jpy',
     )
-    @item_buyer = Item.find(params[:id])
+    @item_buyer = @item
     @item_buyer.update(buyer_id: current_user.id)
     
     flash[:notice] = "#{@item.name}を購入しました"
@@ -104,10 +103,12 @@ class ItemsController < ApplicationController
   end
 
   def set_confimation
-    @item = Item.find(params[:id])
     @image = Image.find(params[:id])
-    @payment = Payment.find_by(user_id: current_user.id)
     @address = Address.find_by(user_id: current_user.id)
+  end
+
+  def set_payment
+    @payment = Payment.find_by(user_id: current_user.id)
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -47,15 +47,13 @@ class ItemsController < ApplicationController
       customer: @payment.customer_id,
       currency: 'jpy',
     )
-    @item_buyer = @item
-    @item_buyer.update(buyer_id: current_user.id)
-    
-    flash[:notice] = "#{@item.name}を購入しました"
-    redirect_to root_path
+    if @item.update(buyer_id: current_user.id)    
+        flash[:notice] = "#{@item.name}を購入しました"
+        redirect_to root_path
+    else 
+        redirect_to confimation_item_path(@item)
+    end
   end
-
-
-
 
   
   # 商品出品アクション

--- a/app/views/items/confimation.html.haml
+++ b/app/views/items/confimation.html.haml
@@ -5,54 +5,70 @@
 -# メイン
 .confimation
   .confimation-main
-    .confimation-main__page
-      %h2.confimation-main__page__title 購入内容の確認
-      .confimation-main__page__content
-        .confimation-main__page__content__inner
-          .confimation-main__page__content__inner__box
-            .confimation-main__page__content__inner__box__image
-              =image_tag "sample-image1.jpg",class:"image"
-            .confimation-main__page__content__inner__box__item
-              %p.item-name 盛りドレスワンピースです
-              %p.item-price
-                %span ¥600 
-                %span (税込み)送料です
-      .confimation-main__page__form
-        %ul.confimation-main__page__form__price
-          %li.confimation-main__page__form__price--pay 支払い金額
-          %li.confimation-main__page__form__price--prices ¥600
-        .confimation-main__page__form__point
-          =icon("fas fa-check-square", class: "icon")
-          %label.confimation-main__page__form__point__label ポイントを使用(所持ポイント:P0)
-        .confimation-main__page__form__buy
-          %h3.confimation-main__page__form__buy__pay 支払い方法
-          -if @payment.present?
-            .mypage-wrapper__contents__right-card-index__content__name__icon
-              -case @payment_brand
-              -when "Visa"
-                =icon("fab fa-cc-visa",class: "icon")
-              -when "MasterCard"
-                =icon("fab fa-cc-mastercard",class: "icon")
-              -when "JCB"
-                =icon("fab fa-cc-jcb",class: "icon")
-              -when "American Express"
-                =icon("fab fa-cc-amex",class: "icon")
-              -when "Discover"
-                =icon("fab fa-cc-discover",class: "icon")
-            .mypage-wrapper__contents__right-card-index__content__name__numbers
-              ="**** **** **** " + @default_card_information.last4
-            .mypage-wrapper__contents__right-card-index__content__name__expiration
-              =@exp_month + "/" + @exp_year
-          -else
-            =icon("fas fa-plus-circle", class: "icon")
-            =link_to "登録してください" ,card_register_users_path(current_user.id),class:"confimation-main__page__form__buy__link"
-        .confimation-main__page__form__delivery
-          %h3.confimation-main__page__form__delivery__address 配送先
-          =icon("fas fa-plus-circle",class: "icon")
-          =link_to "登録してください","#",class: "confimation-main__page__form__delivery__link"
-        .confimation-main__page__form__submit
-          =form_with url: "#"  do  |form| 
-            =form.submit "購入する",class: "confimation-main__page__form__submit--btn"
+    =form_with url:{controller: 'items', action: "pay", method:'post'}  do  |form| 
+      .confimation-main__page
+        %h2.confimation-main__page__title 購入内容の確認
+        .confimation-main__page__content
+          .confimation-main__page__content__inner
+            .confimation-main__page__content__inner__box
+              .confimation-main__page__content__inner__box__image
+                =image_tag @image.url.url ,class:"image"
+              .confimation-main__page__content__inner__box__item
+                =@item.name
+                %p.item-price
+                  %span= "#{@item.price}円" 
+                  %span (税込み)送料です
+        .confimation-main__page__form
+          %ul.confimation-main__page__form__price
+            %li.confimation-main__page__form__price--pay 支払い金額
+            %li.confimation-main__page__form__price--prices ¥#{@item.price}
+          .confimation-main__page__form__point
+            =icon("fas fa-check-square", class: "icon")
+            %label.confimation-main__page__form__point__label ポイントを使用(所持ポイント:P0)
+          .confimation-main__page__form__buy
+            %h3.confimation-main__page__form__buy__pay 支払い方法
+            -if @payment.present?
+              .mypage-wrapper__contents__right-card-index__content__name__icon
+                -case @payment_brand
+                -when "Visa"
+                  =icon("fab fa-cc-visa",class: "icon")
+                -when "MasterCard"
+                  =icon("fab fa-cc-mastercard",class: "icon")
+                -when "JCB"
+                  =icon("fab fa-cc-jcb",class: "icon")
+                -when "American Express"
+                  =icon("fab fa-cc-amex",class: "icon")
+                -when "Discover"
+                  =icon("fab fa-cc-discover",class: "icon")
+              .mypage-wrapper__contents__right-card-index__content__name__numbers
+                ="**** **** **** " + @default_card_information.last4
+              .mypage-wrapper__contents__right-card-index__content__name__expiration
+                =@exp_month + "/" + @exp_year
+            -else
+              =icon("fas fa-plus-circle", class: "icon")
+              =link_to "登録してください" ,new_payment_path(current_user.id),class:"confimation-main__page__form__buy__link"
+          .confimation-main__page__form__delivery
+            %h3.confimation-main__page__form__delivery__address 配送先
+            -if @address.present?
+              .confimation-main__page__form__delivery__
+                =@address.zip_code
+                %br
+                =@address.prefectures
+                %br
+                =@address.city
+                -if @address.address_line1.present?
+                  =@address.address_line1
+                -if  @address.address_line2.present?
+                  =@address.address_line2
+            -else
+              =icon("fas fa-plus-circle",class: "icon")
+              =link_to "登録してください",new_address_path,class: "confimation-main__page__form__delivery__link"
+          -if @item.buyer_id.present?
+            .confimation-main__page__form__submit
+              =link_to "売り切れました",root_path,class:"confimation-main__page__form__submit--buy"
+          -elsif @payment.present? && @address.present?
+            .confimation-main__page__form__submit
+              =form.submit "購入する",class: "confimation-main__page__form__submit--btn"
 
             
 -# フッター 

--- a/app/views/items/confimation.html.haml
+++ b/app/views/items/confimation.html.haml
@@ -50,7 +50,7 @@
           .confimation-main__page__form__delivery
             %h3.confimation-main__page__form__delivery__address 配送先
             -if @address.present?
-              .confimation-main__page__form__delivery__
+              .confimation-main__page__form__delivery__addresses
                 =@address.zip_code
                 %br
                 =@address.prefectures

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -96,9 +96,13 @@
             %br
             = link_to item_path(@item), method: "delete", class:"item-btn__delete" do
               商品を削除する
-        - else  # ログインユーザーが出品者以外の場合、商品購入ボタンが表示される
+        - elsif  @item.buyer_id.present?  # ログインユーザーが出品者以外でbuyer_idに値がある場合の条件分岐
           .item-btn
-            = link_to confimation_items_path(@item), class:"item-btn__buy" do
+            = link_to root_path ,class:"item-btn__sold" do
+              売り切れました
+        - else
+          .item-btn
+            = link_to confimation_item_path, class:"item-btn__buy" do
               購入画面に進む
 
     .comment__box

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,12 @@ Rails.application.routes.draw do
   root to: "items#index"
 
   resources :items, only: [:index, :show, :create, :edit, :destroy] do
-    collection do
+    member do
       get 'confimation'
+      post 'pay'
+    end
+
+    collection do
       get 'exhibition'
       get 'view'
       # 子、孫カテゴリ登録用アクション


### PR DESCRIPTION
#what
payjpを使用して購入(支払い)が出来るように実装を行った

・商品を購入した際、Payjpのコンソールから売り上げが確認できる
・購入が完了するとトップページに偏移
・購入確定画面
　→クレジットカード・配送先の両方登録されていないと購入ボタンが表示されないように修正
・購入後、商品詳細ページには売り切れましたと表示されるように修正(購入できないように)

#why
フリマアプリを作成するのに当たって購入機能は必須のため

画面キャプチャ
購入
https://gyazo.com/2f78529da6f0cea188c450df1ac227fb

購入確定画面(配送先が登録されていない場合)
https://gyazo.com/440553040abe4c6c55f52741d4e09ac9

payjpのコンソール画面
https://gyazo.com/ae55027823075ac505cc2ba452d15807

購入後の商品詳細画面
https://gyazo.com/1bbc36235b1cc859867d613322ade9e0
