### PR TITLE
[WIP] カテゴリ別商品一覧機能の追加

### DIFF
--- a/app/assets/stylesheets/items/_index.scss
+++ b/app/assets/stylesheets/items/_index.scss
@@ -110,7 +110,7 @@
     flex-wrap: wrap;
     width: 780px;
     margin: 26px auto;
-    &__item{
+    &__item, &__ladies, &__mens{
       display: grid;
       width: 220px;
       height: 245px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   
   before_action :set_item, only:[:show, :destroy]
-  
+  before_action :index_category_set, only: :index
+
   def index
     @items = Item.where(buyer_id: nil).includes([:images]).limit(6)
   end
@@ -85,4 +86,16 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def index_category_set  # 人気のカテゴリの取得
+    array = [1, 196]
+    for num in array do
+      search_anc = Category.where('ancestry LIKE(?)', "#{num}/%")
+      ids = []
+      search_anc.each do |i|
+        ids << i[:id]
+      end
+      items = Item.where(category_id: ids).includes([:images]).limit(6)
+      instance_variable_set("@cat_no#{num}", items)
+    end
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,10 @@
 class ItemsController < ApplicationController
   
   before_action :set_item, only:[:show, :destroy]
-  before_action :index_category_set, only: :index
+  before_action :popular_category_set, only: :index
 
   def index
-    @items = Item.where(buyer_id: nil).includes([:images]).limit(6)
+    @items = Item.where(buyer_id: nil).includes([:images]).order("id DESC").limit(6)
   end
 
   def view
@@ -86,16 +86,16 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  def index_category_set  # 人気のカテゴリの取得
-    array = [1, 196]
-    for num in array do
-      search_anc = Category.where('ancestry LIKE(?)', "#{num}/%")
+  def popular_category_set  # 人気のカテゴリの取得
+    popular_category = [1, 196] # レディース(1),メンズ(196)のidを挿入
+    for num in popular_category do
+      ancestry_category = Category.where('ancestry like?', "#{num}/%")  # 親子孫の3階層のカテゴリ情報を一括取得
       ids = []
-      search_anc.each do |i|
-        ids << i[:id]
+      ancestry_category.each do |i|
+        ids << i[:id]  # 親カテゴリに関連するカテゴリのidをidsに挿入
       end
-      items = Item.where(category_id: ids).includes([:images]).limit(6)
-      instance_variable_set("@cat_no#{num}", items)
+      items = Item.where(category_id: ids).includes([:images]).order("id DESC").limit(6)
+      instance_variable_set("@category_no#{num}", items)
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,4 @@ class UsersController < ApplicationController
   def logout
   end
   
-  def addresses
-  end
 end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -95,6 +95,26 @@
               %p= "#{item.price}円"
               %p#tax (税込み)
 
+    %h2.main-categories__title レディース新着アイテム
+    .main-categories__lists
+      - @cat_no1.each do |item|
+        = link_to item_path(id: item.id) ,class:"main-categories__lists__ladies" do
+          - item.images.last(1).each do |image|
+            = image_tag image.url.url
+            .main-categories__lists__ladies__text
+              %p= item.name
+              %p= "#{item.price}円"
+              %p#tax (税込み)
+
+    %h2.main-categories__title メンズ新着アイテム
+    .main-categories__lists
+      - @cat_no196.each do |item|
+        = link_to item_path(id: item.id) ,class:"main-categories__lists__mens" do
+          - item.images.last(1).each do |image|
+            = image_tag image.url.url
+            .main-categories__lists__mens__text
+              %p= item.name
+              %p= "#{item.price}円"
+              %p#tax (税込み)
+
 =render 'layouts/footer'
-
-

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -95,9 +95,10 @@
               %p= "#{item.price}円"
               %p#tax (税込み)
 
+    -# レディースカテゴリの新着商品の一覧表示
     %h2.main-categories__title レディース新着アイテム
     .main-categories__lists
-      - @cat_no1.each do |item|
+      - @category_no1.each do |item|
         = link_to item_path(id: item.id) ,class:"main-categories__lists__ladies" do
           - item.images.last(1).each do |image|
             = image_tag image.url.url
@@ -106,9 +107,10 @@
               %p= "#{item.price}円"
               %p#tax (税込み)
 
+    -# メンズカテゴリの新着商品の一覧表示
     %h2.main-categories__title メンズ新着アイテム
     .main-categories__lists
-      - @cat_no196.each do |item|
+      - @category_no196.each do |item|
         = link_to item_path(id: item.id) ,class:"main-categories__lists__mens" do
           - item.images.last(1).each do |image|
             = image_tag image.url.url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,24 +25,9 @@ Rails.application.routes.draw do
   resources :users, only: [:show] do
     collection do
       get 'logout'
-      get 'card_index'
-      get 'card_register'
     end
   end
 
   resources :payments, only: [:index,:new,:create,:destroy]
   resources :addresses, only: [:new, :create, :edit, :update]
 end
-
-  # items#index         --- トップページ
-  # items#show          --- 商品詳細ページ
-  # items#confimation   --- 商品購入確認ページ
-  # items#exhibition    --- 商品出品ページ
-
-  # users#show          --- ユーザーマイページ
-  # users#logout        --- ログアウト画面
-
-  # payments#index      --- クレジットカード一覧ページ
-  # payments#new        --- クレジットカード登録ページ
-
-  # addresses#new       --- 送付先住所登録


### PR DESCRIPTION
・What
トップページにピックアップしたカテゴリ(レディース、メンズ)の商品一覧表示機能を追加する
キャプチャ動画
https://gyazo.com/68fb797315ecef23236f294b5d94c686
①Itemsコントローラにpopular_category_setメソッドを定義し、ピックアップされた親カテゴリとそれに関連する子孫カテゴリのidを一括取得する
②トップページのhamlファイルに①で取得したidの商品を6つまで降順表示する

・Why
見本フリマサイトの見た目に近づけるため
カテゴリ別に商品を表示させるため

※ヘッダーのカテゴリドロップダウンリストからの一覧表示は後から実装予定です