### PR TITLE
トップページの出品ボタン実装

### DIFF
--- a/app/assets/stylesheets/items/_index.scss
+++ b/app/assets/stylesheets/items/_index.scss
@@ -1,4 +1,35 @@
 // 変数定義
+
+.main {
+  position: relative;
+  .main-icon {
+    position: fixed;
+    bottom: 32px;
+    font-size: 22px;
+    height: 160px;
+    right: 32px;
+    width: 160px;
+    background-color: #3CCACE;
+    border-radius: 50%;
+    overflow: auto;
+    z-index: 2;
+    &__form {
+      width: 160px;
+      height: 160px;
+      padding-top: 32px;
+      text-align: center;
+      &__first {
+        color: white;
+      }
+      &__second {
+        color: white;
+        font-size: 50px;
+      }
+    }
+  }
+}
+
+
 .main-visual {
   background-image: image-url("bg-mainVisual-pict_pc.jpg");
   @include image;

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,6 +1,12 @@
 =render 'layouts/header'
 
 .main
+  .main-icon
+    %a{ href: "/items/exhibition"}
+      .main-icon__form
+        .main-icon__form__first 出品
+        .main-icon__form__second
+          =icon("fas fa-camera",class: "icon")
   .main-visual
     .main-visual__title
       人生を変えるフリマアプリ


### PR DESCRIPTION
#what
トップページに出品ボタンを表示しクリックすると出品ページに偏移する

#why
現在のフリマアプリはマイページに行かないと出品ができないため

画面キャプチャ
https://gyazo.com/e09b11cc180dd077a09e257a0dcd7e00
https://gyazo.com/89eec0def91d84d978d7b49f46943c80
