### PR TITLE
カテゴリー編集フォーム修正

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -8,23 +8,23 @@ $(document).on('turbolinks:load',function(){
   // 子カテゴリのセレクトボックス作成
   function appendChidrenBox(insertHTML){
     let childSelectHtml = '';
-    childSelectHtml = `<div class='listing-select-wrapper__added' id='children_wrapper'>
-                        <div class='listing-select-wrapper__box' id='children_wrapper_box'>
-                          <select class='listing-select-wrapper__box--select' id='child_category' name='item[category_id]'>
+    childSelectHtml = `<div class='exhibition__main__container__category__added' id='children_wrapper'>
+                        <div class='exhibition__main__container__category__box' id='children_wrapper_box'>
+                          <select class='exhibition__main__container__category__box--select' id='child_category' name='item[category_id]'>
                             <option value='---' data-category='---'>選択してください</option>
                             ${insertHTML}
                           </select>
                         </div>
                       </div>`;
-    $('.listing-select-wrapper__box').append(childSelectHtml);
+    $('.exhibition__main__container__category__box').append(childSelectHtml);
   }
 
   // 孫カテゴリのセレクトボックス作成
   function appendGrandchidrenBox(insertHTML){
     let grandchildSelectHtml = '';
-    grandchildSelectHtml = `<div class='listing-select-wrapper__added' id= 'grandchildren_wrapper'>
-                              <div class='listing-select-wrapper__box' id= 'grandchildren_wrapper_box'>
-                                <select class='listing-select-wrapper__box--select' id='grandchild_category' name='item[category_id]'>
+    grandchildSelectHtml = `<div class='exhibition__main__container__category__added' id= 'grandchildren_wrapper'>
+                              <div class='exhibition__main__container__category__box' id= 'grandchildren_wrapper_box'>
+                                <select class='exhibition__main__container__category__box--select' id='grandchild_category' name='item[category_id]'>
                                   <option value='---' data-category='---'>選択してください</option>
                                   ${insertHTML}
                                 </select>
@@ -63,7 +63,7 @@ $(document).on('turbolinks:load',function(){
   });
 
   // 子カテゴリ選択後のイベント
-  $('.listing-select-wrapper__box').on('change', '#child_category', function(){
+  $('.exhibition__main__container__category__box').on('change', '#child_category', function(){
     let childId = $('#child_category option:selected').data('category'); // 選択された子カテゴリのidを取得
     if (childId != "選択してください"){ // 子カテゴリが初期値でないときイベント発火
       $.ajax({

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -1,27 +1,27 @@
 $(document).on('turbolinks:load', function(){
   $(function(){
-
+    
     function buildHTML(count) {
       var html = `<div class="preview-box" id="preview-box__${count}">
-                    <div class="upper-box">
-                      <img src="" alt="preview">
-                    </div>
-                    <div class="lower-box">
-                      
-                      <div class="delete-box" id="delete_btn_${count}">
-                        <span>削除</span>
-                      </div>
-                    </div>
-                  </div>`
+      <div class="upper-box">
+      <img src="" alt="preview">
+      </div>
+      <div class="lower-box">
+      
+      <div class="delete-box" id="delete_btn_${count}">
+      <span>削除</span>
+      </div>
+      </div>
+      </div>`
       return html;
     }
+    
+    //共通の定数を定義==================================================================
+    var class_label = $(".label-content");
+    var class_box = $(".label-box");
 
     // 編集
     if (window.location.href.match(/\/items\/\d+\/edit/)){
-      //登録済み画像のプレビュー表示欄の要素を取得する
-      var prevContent = $('.label-content').prev();
-      labelWidth = (620 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
-      $('.label-content').css('width', labelWidth);
       //プレビューにidを追加
       $('.preview-box').each(function(index, box){
         $(box).attr('id', `preview-box__${index}`);
@@ -33,27 +33,23 @@ $(document).on('turbolinks:load', function(){
       var count = $('.preview-box').length;
       //プレビューが5あるときは、投稿ボックスを消しておく
       if (count == 5) {
-        $('.label-content').hide();
+        class_label.hide();
       }
     }
     
+    //登録済み画像のプレビュー表示欄の要素を取得する
     function setLabel() {
-      var prevContent = $('.label-content').prev();
+      var prevContent = class_label.prev();
       labelWidth = (620 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
-      $('.label-content').css('width', labelWidth);
+      class_label.css('width', labelWidth);
     }
     
-    
-
-
-
-
     $(document).on('change', '.hidden-field', function() {
       setLabel();
       //hidden-fieldのidの数値のみ取得
       var id = $(this).attr('id').replace(/[^0-9]/g, '');
       //labelボックスのidとforを更新
-      $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
+      class_box.attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
       //選択したfileのオブジェクトを取得
       var file = this.files[0];
       var reader = new FileReader();
@@ -67,7 +63,7 @@ $(document).on('turbolinks:load', function(){
           var count = $('.preview-box').length;
           var html = buildHTML(id);
           //ラベルの直前のプレビュー群にプレビューを追加
-          var prevContent = $('.label-content').prev();
+          var prevContent = class_label.prev();
           $(prevContent).append(html);
         }
         //イメージを追加
@@ -75,7 +71,7 @@ $(document).on('turbolinks:load', function(){
         var count = $('.preview-box').length;
         //プレビューが5個あったらラベルを隠す 
         if (count == 5) { 
-          $('.label-content').hide();
+          class_label.hide();
         }
 
         if ($(`#item_images_attributes_${id}__destroy`)){
@@ -87,7 +83,7 @@ $(document).on('turbolinks:load', function(){
         //ラベルのidとforの値を変更
         if(count < 5){
           //プレビューの数でラベルのオプションを更新する
-          $('.label-box').attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_url`});
+          class_box.attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_url`});
         }
       }
     });
@@ -107,55 +103,47 @@ $(document).on('turbolinks:load', function(){
         var count = $('.preview-box').length;
         //5個めが消されたらラベルを表示
         if (count == 4) {
-          $('.label-content').show();
+          class_label.show();
         }
         setLabel(count);
         if(id < 5){
-          $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
+          class_box.attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
         }
       } else {
         //投稿編集時
         $(`#item_images_attributes_${id}__destroy`).prop('checked',true);
         //5個めが消されたらラベルを表示
         if (count == 4) {
-          $('.label-content').show();
+          class_label.show();
         }
         //ラベルのwidth操作
         setLabel();
         //ラベルのidとforの値を変更
         //削除したプレビューのidによって、ラベルのidを変更する
         if(id < 5){
-          $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
+          class_box.attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
         }
       }
     });
   });
 })
 
-
-
-
-
-
-
-
-
-
 $(document).on('turbolinks:load', function(){
   //共通の定数を定義==================================================================
-  const prevContent = $('.label-content').prev();
+  var class_label = $(".label-content");
+  const prevContent = class_label.prev();
 
   //ラベルのwidth・id・forの値を変更==================================================
   function setLabel(count) {
     //プレビューが5個あったらラベルを隠す
     if (count == 5) { 
-      $('.label-content').hide();
+      class_label.hide();
     } else {
       //プレビューが4個以下の場合はラベルを表示
-      $('.label-content').show();
+      class_label.show();
       //プレビューボックスのwidthを取得し、maxから引くことでラベルのwidthを決定
       labelWidth = (620 - parseInt($(prevContent).css('width')));
-      $('.label-content').css('width', labelWidth);
+      class_label.css('width', labelWidth);
       //id・forの値を変更
       $('.label-box').attr({for: `item_images_attributes_${count}_url`});
     }

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -1,24 +1,20 @@
 $(document).on('turbolinks:load', function(){
   $(function(){
-    
+
     function buildHTML(count) {
       var html = `<div class="preview-box" id="preview-box__${count}">
-      <div class="upper-box">
-      <img src="" alt="preview">
-      </div>
-      <div class="lower-box">
-      
-      <div class="delete-box" id="delete_btn_${count}">
-      <span>削除</span>
-      </div>
-      </div>
-      </div>`
+                    <div class="upper-box">
+                      <img src="" alt="preview">
+                    </div>
+                    <div class="lower-box">
+                      
+                      <div class="delete-box" id="delete_btn_${count}">
+                        <span>削除</span>
+                      </div>
+                    </div>
+                  </div>`
       return html;
     }
-    
-    //共通の定数を定義==================================================================
-    var class_label = $(".label-content");
-    var class_box = $(".label-box");
 
     // 編集
     if (window.location.href.match(/\/items\/\d+\/edit/)){
@@ -33,15 +29,14 @@ $(document).on('turbolinks:load', function(){
       var count = $('.preview-box').length;
       //プレビューが5あるときは、投稿ボックスを消しておく
       if (count == 5) {
-        class_label.hide();
+        $('.label-content').hide();
       }
     }
     
-    //登録済み画像のプレビュー表示欄の要素を取得する
     function setLabel() {
-      var prevContent = class_label.prev();
+      var prevContent = $('.label-content').prev();
       labelWidth = (620 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
-      class_label.css('width', labelWidth);
+      $('.label-content').css('width', labelWidth);
     }
     
     $(document).on('change', '.hidden-field', function() {
@@ -49,7 +44,7 @@ $(document).on('turbolinks:load', function(){
       //hidden-fieldのidの数値のみ取得
       var id = $(this).attr('id').replace(/[^0-9]/g, '');
       //labelボックスのidとforを更新
-      class_box.attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
+      $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
       //選択したfileのオブジェクトを取得
       var file = this.files[0];
       var reader = new FileReader();
@@ -63,7 +58,7 @@ $(document).on('turbolinks:load', function(){
           var count = $('.preview-box').length;
           var html = buildHTML(id);
           //ラベルの直前のプレビュー群にプレビューを追加
-          var prevContent = class_label.prev();
+          var prevContent = $('.label-content').prev();
           $(prevContent).append(html);
         }
         //イメージを追加
@@ -71,7 +66,7 @@ $(document).on('turbolinks:load', function(){
         var count = $('.preview-box').length;
         //プレビューが5個あったらラベルを隠す 
         if (count == 5) { 
-          class_label.hide();
+          $('.label-content').hide();
         }
 
         if ($(`#item_images_attributes_${id}__destroy`)){
@@ -83,7 +78,7 @@ $(document).on('turbolinks:load', function(){
         //ラベルのidとforの値を変更
         if(count < 5){
           //プレビューの数でラベルのオプションを更新する
-          class_box.attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_url`});
+          $('.label-box').attr({id: `label-box--${count}`,for: `item_images_attributes_${count}_url`});
         }
       }
     });
@@ -103,25 +98,25 @@ $(document).on('turbolinks:load', function(){
         var count = $('.preview-box').length;
         //5個めが消されたらラベルを表示
         if (count == 4) {
-          class_label.show();
+          $('.label-content').show();
         }
         setLabel(count);
         if(id < 5){
-          class_box.attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
+          $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
         }
       } else {
         //投稿編集時
         $(`#item_images_attributes_${id}__destroy`).prop('checked',true);
         //5個めが消されたらラベルを表示
         if (count == 4) {
-          class_label.show();
+          $('.label-content').show();
         }
         //ラベルのwidth操作
         setLabel();
         //ラベルのidとforの値を変更
         //削除したプレビューのidによって、ラベルのidを変更する
         if(id < 5){
-          class_box.attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
+          $('.label-box').attr({id: `label-box--${id}`,for: `item_images_attributes_${id}_url`});
         }
       }
     });
@@ -130,20 +125,19 @@ $(document).on('turbolinks:load', function(){
 
 $(document).on('turbolinks:load', function(){
   //共通の定数を定義==================================================================
-  var class_label = $(".label-content");
-  const prevContent = class_label.prev();
+  const prevContent = $('.label-content').prev();
 
   //ラベルのwidth・id・forの値を変更==================================================
   function setLabel(count) {
     //プレビューが5個あったらラベルを隠す
     if (count == 5) { 
-      class_label.hide();
+      $('.label-content').hide();
     } else {
       //プレビューが4個以下の場合はラベルを表示
-      class_label.show();
+      $('.label-content').show();
       //プレビューボックスのwidthを取得し、maxから引くことでラベルのwidthを決定
       labelWidth = (620 - parseInt($(prevContent).css('width')));
-      class_label.css('width', labelWidth);
+      $('.label-content').css('width', labelWidth);
       //id・forの値を変更
       $('.label-box').attr({for: `item_images_attributes_${count}_url`});
     }

--- a/app/assets/stylesheets/items/_exhibition.scss
+++ b/app/assets/stylesheets/items/_exhibition.scss
@@ -324,7 +324,6 @@
           width: 120px;
           height: 20px;
           line-height: 20px;
-          // border: 1px solid #eee;
           background: #f5f5f5;
       
         }

--- a/app/assets/stylesheets/items/_exhibition.scss
+++ b/app/assets/stylesheets/items/_exhibition.scss
@@ -79,7 +79,7 @@
           }
         }
       }
-      .listing-select-wrapper__box--select{
+      .exhibition__main__container__category__box--select{
         margin-bottom: 14px;
         height: 46px;
         width: 620px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   
-  before_action :set_item, only:[:show, :destroy, :confimation, :pay, :new, :edit]
+  before_action :set_item, only:[:show, :destroy, :confimation, :pay, :edit, :update]
   before_action :set_confimation, only: :confimation
   before_action :set_payment, only: [:confimation, :pay]
   before_action :popular_category_set, only: :index
@@ -20,9 +20,23 @@ class ItemsController < ApplicationController
   end
   
   def edit
-    @category_parent_array = Category.where(ancestry: nil)
+    grandchild_category = @item.category
+    child_category = grandchild_category.parent
+    @category_parent_array = []
+    Category.where(ancestry: nil).each do |parent|
+      @category_parent_array << parent.name
+    end
+    @category_children_array = []
+    Category.where(ancestry: child_category.ancestry).each do |children|
+      @category_children_array << children
+    end
+    @category_grandchildren_array = []
+    Category.where(ancestry: grandchild_category.ancestry).each do |grandchildren|
+      @category_grandchildren_array << grandchildren
+    end
+    
   end
-
+  
   def update
     if @item.update(item_params)
       flash[:notice] = "#{@item.name}の商品情報を修正しました"  

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -46,13 +46,16 @@
 
       .exhibition__main__container
         %p 商品の詳細
-        .exhibition__main__container__topic__category
+        .exhibition__main__container__topic
           %label カテゴリー
           %span 必須
-
-        .listing-select-wrapper
-          .listing-select-wrapper__box
-            = form.collection_select :category_id, @category_parent_array, :id, :name, {prompt:"選択してください"}, {class: 'listing-select-wrapper__box--select', id: 'parent_category'}
+        .exhibition__main__container__category
+        
+        = form.select :parent_id, @category_parent_array, {selected:@item.category.parent.parent.name}, { class: 'exhibition__main__container__category__box--select', id: 'parent_category'}
+        .exhibition__main__container__category
+          = form.select :child_id, options_for_select(@category_children_array.map{|b| [b.name, b.id, {data:{category: b.id}}]}, {prompt: "指定なし", selected: @item.category.parent.id}),{}, {class: 'exhibition__main__container__category__box--select', id: 'child_category'}
+        .exhibition__main__container__category
+          = form.select :category_id, options_for_select(@category_grandchildren_array.map{|b| [b.name, b.id, {data:{category: b.id}}]}, {prompt: "指定なし", selected: @item.category.id}),{}, {class: 'exhibition__main__container__category__box--select', id: 'grandchild_category'}
 
         .exhibition__main__container__topic
           %label 商品の状態

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,11 +1,9 @@
 .exhibition
   .exhibition__top
-    = link_to image_tag('logo.png',height:"49px",width:"185px",class:"logo"), root_path # ロゴのリンク先をトップページへ指定
+    = link_to image_tag('logo.png',height:"49px",width:"185px",class:"logo"), root_path 
   .exhibition__main
     =form_with(model: @item,local:true,class:"sell-form dropzone", id:"item-dropzone") do |form|
       = render 'layouts/error_messages', model: form.object
-
-
 
       .exhibition__main__container
         .exhibition__main__container__topic
@@ -52,7 +50,6 @@
           %label カテゴリー
           %span 必須
 
-        -# ↓カテゴリ選択欄の表示（渡辺）
         .listing-select-wrapper
           .listing-select-wrapper__box
             = form.collection_select :category_id, @category_parent_array, :id, :name, {prompt:"選択してください"}, {class: 'listing-select-wrapper__box--select', id: 'parent_category'}

--- a/app/views/items/exhibition.html.haml
+++ b/app/views/items/exhibition.html.haml
@@ -38,14 +38,13 @@
 
       .exhibition__main__container
         %p 商品の詳細
-        .exhibition__main__container__topic__category
+        .exhibition__main__container__topic
           %label カテゴリー
           %span 必須
 
-        -# ↓カテゴリ選択欄の表示（渡辺）
-        .listing-select-wrapper
-          .listing-select-wrapper__box
-            = form.collection_select :category_id, @category_parent_array, :id, :name, {prompt:"選択してください"}, {class: 'listing-select-wrapper__box--select', id: 'parent_category'}
+        .exhibition__main__container__category
+          .exhibition__main__container__category__box
+            = form.collection_select :category_id, @category_parent_array, :id, :name, {prompt:"選択してください"}, {class: 'exhibition__main__container__category__box--select', id: 'parent_category'}
 
         .exhibition__main__container__topic
           %label 商品の状態


### PR DESCRIPTION
# what
- 編集ページのカテゴリー選択フォームが展開された状態で表示されるように実装した。
- カテゴリー機能のclass名を、BEMに規則に則りviewファイルのclass名と合うように変更した。
- 前回のマージで画像選択の挙動にエラーが生じていたので、item.jsを修正しエラーを解消した。

<a href="https://gyazo.com/ac962a1c756c8f70d92979b7d51abb16"><img src="https://i.gyazo.com/ac962a1c756c8f70d92979b7d51abb16.gif" alt="Image from Gyazo" width="1000"/></a>
<a href="https://gyazo.com/3cea9984a80ee18587408054e05cd077"><img src="https://i.gyazo.com/3cea9984a80ee18587408054e05cd077.gif" alt="Image from Gyazo" width="1000"/></a>